### PR TITLE
feat(content): add Lightning async payments topic to socratic seminar 12

### DIFF
--- a/content/2026-07-29-socratic-seminar-12.md
+++ b/content/2026-07-29-socratic-seminar-12.md
@@ -43,6 +43,7 @@ pero no esta permitido revelar quien hizo ningun comentario en particular. El ob
 - [Prototyping of self-evolving, democratic, and decentralized systems](https://arxiv.org/abs/2606.25559)
 - [Reverse engineering report: Canaan A3197S](https://github.com/CryptoIceMLH/Nano3S)
 - [Silent payments: harvest-now-decrypt-later attack](https://conduition.io/cryptography/hndl-silent-payments/)
+- [Lightning async payments: receiving while offline](https://lightningdevkit.org/blog/async-payments-receiving-while-offline)
 
 ### Lanzamientos:
 - [Signal + Bitcoin](https://radar.chat/)


### PR DESCRIPTION
Para recibir un pago por la red Lightning es necesario estar conectado en ese preciso momento. Si el destinatario tiene el teléfono apagado o sin señal, el pago no se concreta. Los pagos asincrónicos resuelven esa limitación: el dinero queda a la espera hasta que la persona vuelva a conectarse.

Es una restricción que empuja a mucha gente hacia servicios que custodian los fondos por ella, de modo que resolverla tiene efecto directo sobre el uso cotidiano de Bitcoin como medio de pago.

Es el tema más tratado de la red BitDevs: aparece en 22 de las 29 sedes cuyo temario revisé. El enlace apunta al informe de implementación de LDK, que explica el mecanismo y su estado actual.

---

Este PR forma parte de un conjunto de cinco temas propuestos para el #12, cada uno en su propio PR para que puedan incorporar los que les interesen y descartar el resto. Salen de revisar los temarios publicados por las 44 sedes del directorio oficial (bitdevs.org/cities): 29 tenían temario utilizable, con 1.040 temas en total, que agrupé por materia para ver qué está discutiendo la red.
