### PR TITLE
feat(content): add BGP hijack detection topic to socratic seminar 12

### DIFF
--- a/content/2026-07-29-socratic-seminar-12.md
+++ b/content/2026-07-29-socratic-seminar-12.md
@@ -43,6 +43,7 @@ pero no esta permitido revelar quien hizo ningun comentario en particular. El ob
 - [Prototyping of self-evolving, democratic, and decentralized systems](https://arxiv.org/abs/2606.25559)
 - [Reverse engineering report: Canaan A3197S](https://github.com/CryptoIceMLH/Nano3S)
 - [Silent payments: harvest-now-decrypt-later attack](https://conduition.io/cryptography/hndl-silent-payments/)
+- [HOWLR: A Client-Driven Approach to BGP Hijack Detection](https://arxiv.org/abs/2606.21845)
 
 ### Lanzamientos:
 - [Signal + Bitcoin](https://radar.chat/)


### PR DESCRIPTION
Internet funciona mediante empresas que se transfieren tráfico entre sí siguiendo anuncios de ruta: cada una informa a las demás qué destinos puede alcanzar. Esos anuncios pueden falsificarse, y quien lo hace es capaz de aislar nodos de Bitcoin del resto de la red sin modificar una sola línea del protocolo.

El artículo propone un método para detectar ese tipo de ataque desde el propio cliente. Es un ángulo poco frecuente: la seguridad de Bitcoin discutida en la capa de red y no en la del protocolo.

Los temas de red y P2P aparecen en 14 de las 29 sedes revisadas.

---

Este PR forma parte de un conjunto de cinco temas propuestos para el #12, cada uno en su propio PR para que puedan incorporar los que les interesen y descartar el resto.
