### PR TITLE
feat(content): add BIP-110 topic to socratic seminar 12

### DIFF
--- a/content/2026-07-29-socratic-seminar-12.md
+++ b/content/2026-07-29-socratic-seminar-12.md
@@ -43,6 +43,7 @@ pero no esta permitido revelar quien hizo ningun comentario en particular. El ob
 - [Prototyping of self-evolving, democratic, and decentralized systems](https://arxiv.org/abs/2606.25559)
 - [Reverse engineering report: Canaan A3197S](https://github.com/CryptoIceMLH/Nano3S)
 - [Silent payments: harvest-now-decrypt-later attack](https://conduition.io/cryptography/hndl-silent-payments/)
+- [BIP-110: Reduced Data Temporary Softfork](https://bip110.org/)
 
 ### Lanzamientos:
 - [Signal + Bitcoin](https://radar.chat/)


### PR DESCRIPTION
La cadena de bloques de Bitcoin se utiliza también para almacenar imágenes, textos y otros datos que no representan transferencias de dinero. Para una parte de la comunidad eso encarece las transacciones de todos; para otra es un uso legítimo que nadie debería poder impedir.

BIP-110 propone limitar temporalmente ese almacenamiento. Requiere el apoyo del 55% de la capacidad de minado y actualmente reúne 1,17%. El plazo vence en agosto de 2026.

Más allá del contenido, la discusión trata sobre quién decide los cambios en Bitcoin: uno de los principales pools puso el asunto a votación entre sus mineros, y hay posiciones públicas enfrentadas.

**Es el tema más oportuno para este seminario en particular:** el plazo vence en agosto, de modo que tratarlo el 29 de julio permite discutirlo mientras la decisión sigue abierta. Para el #13 la discusión ya estará resuelta.

Está presente en 12 de las 29 sedes revisadas.

---

Este PR forma parte de un conjunto de cinco temas propuestos para el #12, cada uno en su propio PR para que puedan incorporar los que les interesen y descartar el resto.
